### PR TITLE
[FEAT] axios interceptor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,3 +1,3 @@
-export const UNAUTHENTICATED_ROUTES = ['login'];
+const UNAUTHENTICATED_ROUTES = ['login'];
 
-export const BASE_URL = 'https://36b32v1d09.execute-api.sa-east-1.amazonaws.com/';
+export default UNAUTHENTICATED_ROUTES;

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,0 +1,3 @@
+export const UNAUTHENTICATED_ROUTES = ['login'];
+
+export const BASE_URL = 'https://36b32v1d09.execute-api.sa-east-1.amazonaws.com/';

--- a/src/service/axiosInstance.jsx
+++ b/src/service/axiosInstance.jsx
@@ -1,7 +1,28 @@
 import axios from 'axios';
+import { getSessionStorage } from '../utils/sessionStorage';
+import { UNAUTHENTICATED_ROUTES, BASE_URL } from '../constants/constants';
 
 const axiosInstance = axios.create({
-  baseURL: 'https://36b32v1d09.execute-api.sa-east-1.amazonaws.com/',
+  baseURL: BASE_URL,
+});
+
+axiosInstance.interceptors.request.use((req) => {
+  const token = getSessionStorage('token');
+
+  const isUnauthenticatedRoute = UNAUTHENTICATED_ROUTES.includes(req.url);
+
+  if (isUnauthenticatedRoute) {
+    return req;
+  }
+
+  if (token) {
+    req.headers = {
+      Authorization: `Bearer ${token}`,
+    };
+    return req;
+  }
+
+  return console.log('token não informado no sessionStorage');
 });
 
 export default axiosInstance;

--- a/src/service/axiosInstance.jsx
+++ b/src/service/axiosInstance.jsx
@@ -16,7 +16,9 @@ axiosInstance.interceptors.request.use((req) => {
   }
 
   if (token) {
+    const { headers } = req
     req.headers = {
+      ...headers,
       Authorization: `Bearer ${token}`,
     };
     return req;

--- a/src/service/axiosInstance.jsx
+++ b/src/service/axiosInstance.jsx
@@ -1,9 +1,9 @@
 import axios from 'axios';
 import { getSessionStorage } from '../utils/sessionStorage';
-import { UNAUTHENTICATED_ROUTES, BASE_URL } from '../constants/constants';
+import UNAUTHENTICATED_ROUTES from '../constants/constants';
 
 const axiosInstance = axios.create({
-  baseURL: BASE_URL,
+  baseURL: import.meta.env.VITE_API_BASE_URL,
 });
 
 axiosInstance.interceptors.request.use((req) => {
@@ -16,7 +16,7 @@ axiosInstance.interceptors.request.use((req) => {
   }
 
   if (token) {
-    const { headers } = req
+    const { headers } = req;
     req.headers = {
       ...headers,
       Authorization: `Bearer ${token}`,
@@ -24,7 +24,7 @@ axiosInstance.interceptors.request.use((req) => {
     return req;
   }
 
-  throw new Error('missing token in sessionStorage')
+  throw new Error('missing token in sessionStorage');
 });
 
 export default axiosInstance;

--- a/src/service/axiosInstance.jsx
+++ b/src/service/axiosInstance.jsx
@@ -24,7 +24,7 @@ axiosInstance.interceptors.request.use((req) => {
     return req;
   }
 
-  return console.log('token não informado no sessionStorage');
+  throw new Error('missing token in sessionStorage')
 });
 
 export default axiosInstance;


### PR DESCRIPTION
## Tipo

- [x] Nova funcionalidade
- [ ]  Correção de bug
- [ ] Refatoração
- [x] Alteração de configuração de ambiente
- [ ] Outros

## Motivo
Precisavamos adicionar um interceptor para as requisições que necessitam de token

## O que foi feito

- Utilizando axios, foi criado um interceptor que adiciona no header das requisições o token recuperado do session storage.

- Foi criada uma variável de ambiente que contém a base url da API

- Também foi criado um arquivo de constantes onde foi adicionado os endpoints que não necessitam de token. 

## Anexos 

Para **testar** que o interceptor estava funcionando de forma adequada, realizei uma **chamada qualquer** a API na página home 

```
useEffect(() => {
    axiosInstance.get('get/volunteers?limit=3&offset=brunaccelestino@gmail.com').then((data) => {
      console.log(data.data);
    });
  }, []);
```

e obtive o seguinte resultado

![image](https://user-images.githubusercontent.com/91629999/195401937-6a33d023-64de-441f-aa3a-b7976da1e1dd.png)
![image](https://user-images.githubusercontent.com/91629999/195402138-a4c63d6c-24e0-41aa-a784-c40ef8e97843.png)


