### PR TITLE
[REFACTOR] Remove z-index do campo de pesquisa por voluntário

### DIFF
--- a/src/pages/Volunteers.jsx
+++ b/src/pages/Volunteers.jsx
@@ -101,7 +101,7 @@ export default function Volunteers() {
           Voluntários
         </h1>
         <form onSubmit={handleSubmit(onSubmit)}>
-          <div className="relative z-[-1]">
+          <div className="relative">
             <input
               className="border-primary-black border w-full py-3 px-6 rounded-full text-primary-black placeholder:text-medium-grey"
               type="text"


### PR DESCRIPTION
## Tipo
- [ ] Nova funcionalidade
- [x] Correção de bug
- [ ] Refatoração
- [ ] Alteração de configuração de ambiente
- [ ] Outros

## Motivo

Na ultima pr eu tinha adicionado z-index negativo ao campo de pesquisa para prevenir que ele ficasse por cima da sidebar. Mas não percebi que essa alteração não estava permitindo a escrita no campo, o time de QA me passou esse problema então vou retirar.

## O que foi feito
- Foi removida a propriedade z-index


## Anexos

Como estava com a propriedade z-index
[Video-Thu-Dec-15-2022-11-51-22.webm](https://user-images.githubusercontent.com/91629999/207892787-cd14a38a-c0ef-45e6-92e0-3cfffe4b6478.webm)

Como está agora
[Video-Thu-Dec-15-2022-11-51-02.webm](https://user-images.githubusercontent.com/91629999/207892779-ea66cfa3-0086-4278-9c12-21f7d059cdc6.webm)
