### PR TITLE
Medicine Read Filter

### DIFF
--- a/src/components/Medicine/Medicine.jsx
+++ b/src/components/Medicine/Medicine.jsx
@@ -3,7 +3,6 @@
 /* eslint-disable max-len */
 /* eslint-disable react/prop-types */
 import React from 'react';
-
 import { Link } from 'react-router-dom';
 import trashIcon from '../../assets/trash.svg';
 import detailsIcon from '../../assets/details.svg';
@@ -32,6 +31,9 @@ export default function Medicine({
 
   return (
     <>
+      <td className="text-center">
+        <p>{medicine?.wasRead ? 'Lido' : 'Não lido'}</p>
+      </td>
       <td className="text-center">
         <p>{medicine?.fullName}</p>
       </td>

--- a/src/components/Medicine/Medicine.jsx
+++ b/src/components/Medicine/Medicine.jsx
@@ -10,7 +10,6 @@ import { useToast } from '../../contexts/toastContext';
 import { usePermissions } from '../../contexts/permissionsContext';
 import { ADMIN_MASTER } from '../../data/permissions';
 import formatExpirationDate from '../../utils/formatExpirationDate';
-import ToastContainer from '../Toast/ToastContainer';
 
 export default function Medicine({
   medicine,
@@ -63,7 +62,6 @@ export default function Medicine({
           </button>
         </div>
       </td>
-      <ToastContainer />
     </>
   );
 }

--- a/src/data/medicinesTableHeaders.js
+++ b/src/data/medicinesTableHeaders.js
@@ -1,5 +1,8 @@
 export default [
   {
+    title: 'Status',
+  },
+  {
     title: 'Nome',
   },
   {

--- a/src/pages/Medicines.jsx
+++ b/src/pages/Medicines.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
 /* eslint-disable react/jsx-no-bind */
 import React, { useState, useEffect } from 'react';
 import AuthenticatedLayout from '../layouts/AuthenticatedLayout';
@@ -7,13 +8,28 @@ import Medicine from '../components/Medicine';
 import Modal from '../components/Modal';
 import { fetchMedicines, deleteMedicine } from '../service/apiRequests/medicines';
 import { useToast } from '../contexts/toastContext';
+import ToastContainer from '../components/Toast/ToastContainer';
 
 export default function Medicines() {
   const [medicines, setMedicines] = useState([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [medicineToBeDeleted, setMedicineToBeDeleted] = useState({});
+  const [viewFilter, setViewFilter] = useState('unread');
 
   const { addToast } = useToast();
+
+  const viewMode = (view, medicine) => {
+    switch (view) {
+      case 'read':
+        return medicine?.wasRead;
+
+      case 'unread':
+        return !medicine?.wasRead;
+
+      default:
+        return true;
+    }
+  };
 
   const openModal = () => {
     setIsModalOpen(true);
@@ -58,6 +74,20 @@ export default function Medicines() {
           Medicamentos
         </h1>
         <span className="leading-6 text-primary-black">Consulte os medicamentos em estoque, doados através do formulário fixado no site.</span>
+        <div className="mt-8">
+          <label htmlFor="view" className="font-medium text-lg">Exibir:</label>
+          <select
+            name="view"
+            id="view"
+            defaultValue={viewFilter}
+            className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block cursor-pointer p-2"
+            onChange={(e) => setViewFilter(e.target.value)}
+          >
+            <option value="all">Todos</option>
+            <option value="unread">Apenas não lidos</option>
+            <option value="read">Apenas lidos</option>
+          </select>
+        </div>
 
         {!medicines.length ? (
           <div className="mt-[134px] flex flex-col items-center">
@@ -82,16 +112,18 @@ export default function Medicines() {
                 </tr>
               </thead>
               <tbody>
-                {medicines.map((medicine, index) => (
-                  <tr key={medicine.id} className={`h-20 ${index % 2 === 0 ? 'bg-base' : 'bg-light-grey'}`}>
-                    <Medicine
-                      key={medicine.id}
-                      medicine={medicine}
-                      openModal={openModal}
-                      setMedicineToBeDeleted={setMedicineToBeDeleted}
-                    />
-                  </tr>
-                ))}
+                {medicines
+                  .filter((medicine) => viewMode(viewFilter, medicine))
+                  .map((medicine, index) => (
+                    <tr key={medicine.id} className={`h-20 ${index % 2 === 0 ? 'bg-base' : 'bg-light-grey'}`}>
+                      <Medicine
+                        key={medicine.id}
+                        medicine={medicine}
+                        openModal={openModal}
+                        setMedicineToBeDeleted={setMedicineToBeDeleted}
+                      />
+                    </tr>
+                  ))}
               </tbody>
             </table>
 
@@ -108,6 +140,7 @@ export default function Medicines() {
       >
         <span>Deseja mesmo realizar essa exclusão?</span>
       </Modal>
+      <ToastContainer />
     </AuthenticatedLayout>
   );
 }

--- a/src/pages/Medicines.jsx
+++ b/src/pages/Medicines.jsx
@@ -89,7 +89,6 @@ export default function Medicines() {
                       medicine={medicine}
                       openModal={openModal}
                       setMedicineToBeDeleted={setMedicineToBeDeleted}
-
                     />
                   </tr>
                 ))}


### PR DESCRIPTION
# Medicine Read Filter

Add Read Filter to Medicine Page. Table View is modified according with the filter + `wasRead` field from API return.

**News**

- Add column `Status` to the table view. Possible values:
  - Lido: `wasRead === true`
  - Não lido: `wasRead === false`
- Add `viewFilter` select input. Values/logic and labels mapping:
  - `read` => `wasRead === true`: Lido
  - `unread` => `wasRead === false`: Não lido
  - `all` => always `true`: Todos 

**Quick fix**

`ToastContainer` is moved from `Medicine` component (inside a `tr` tag) to the `MedicinePage` component (inside a `React.fragment`). The previous approach was leading to a warning since `div`s (root element of `ToastContainer` component) should not be a direct child of a `tr`.